### PR TITLE
Allow splitting the API into chunks

### DIFF
--- a/app/Options.hs
+++ b/app/Options.hs
@@ -56,9 +56,15 @@ configParser = Config
     (  long "ghc-options"
     <> value ""
     )
+  <*> option auto
+    (  long "chunk-size"
+    <> short 's'
+    <> value 32
+    )
 
 data Config = Config
   { packageName :: Text
   , isHandlerModule :: Pattern'
   , ghcOptions :: Text
+  , chunkSize :: Int
   }

--- a/package.yaml
+++ b/package.yaml
@@ -22,7 +22,6 @@ executable:
     - hpack
     - mtl
     - optparse-applicative
-    - parser-combinators
     - regex-base
     - regex-tdfa >= 1.3.1.0
     - text
@@ -36,6 +35,8 @@ ghc-options:
   - -Wno-missing-export-lists
   - -Wno-missing-exported-signatures
   - -Wno-missing-import-lists
+  - -Wno-missing-safe-haskell-mode
+  - -Wno-prepositive-qualified-module
   - -Wno-redundant-constraints
   - -Wno-safe
   - -Wno-unsafe

--- a/servant-serf-example/src/Foo/Api.hs
+++ b/servant-serf-example/src/Foo/Api.hs
@@ -1,8 +1,8 @@
 -- | test Api module
 
-{-# OPTIONS_GHC -F -pgmF servant-serf 
-  -optF --package-name=servant-serf-example 
-  -optF --is-handler-module=Foo.Handler.* 
+{-# OPTIONS_GHC -F -pgmF servant-serf
+  -optF --package-name=servant-serf-example
+  -optF --is-handler-module=Foo.Handler.*
 #-}
 
 module Foo.Api where

--- a/servant-serf.cabal
+++ b/servant-serf.cabal
@@ -1,10 +1,8 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 34ad605e11a027728374e1a7958d21c53da6ec8141892add6751250fc9a221b2
 
 name:           servant-serf
 version:        0.1.1
@@ -17,10 +15,7 @@ license-file:   LICENSE
 build-type:     Simple
 
 library
-  ghc-options: -Weverything -Wno-all-missed-specializations -Wno-implicit-prelude -Wno-missed-specialisations -Wno-missing-deriving-strategies -Wno-missing-export-lists -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-redundant-constraints -Wno-safe -Wno-unsafe
-  if false
-    other-modules:
-        Paths_servant_serf
+  ghc-options: -Weverything -Wno-all-missed-specializations -Wno-implicit-prelude -Wno-missed-specialisations -Wno-missing-deriving-strategies -Wno-missing-export-lists -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-redundant-constraints -Wno-safe -Wno-unsafe
   default-language: Haskell2010
 
 executable servant-serf
@@ -31,18 +26,14 @@ executable servant-serf
       Regex
   hs-source-dirs:
       app
-  ghc-options: -Weverything -Wno-all-missed-specializations -Wno-implicit-prelude -Wno-missed-specialisations -Wno-missing-deriving-strategies -Wno-missing-export-lists -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-redundant-constraints -Wno-safe -Wno-unsafe
+  ghc-options: -Weverything -Wno-all-missed-specializations -Wno-implicit-prelude -Wno-missed-specialisations -Wno-missing-deriving-strategies -Wno-missing-export-lists -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-redundant-constraints -Wno-safe -Wno-unsafe
   build-depends:
       attoparsec
     , base <=5.2.0.0
     , hpack
     , mtl
     , optparse-applicative
-    , parser-combinators
     , regex-base
     , regex-tdfa >=1.3.1.0
     , text
-  if false
-    other-modules:
-        Paths_servant_serf
   default-language: Haskell2010


### PR DESCRIPTION
Story details: https://app.clubhouse.io/itprotv/story/85963

Since "chunks" isn't a well-defined term, here's what I mean:

``` hs
type ApiCreamy
  =    "1" :> Get '[JSON] Int
  :<|> "2" :> Get '[JSON] Int
  :<|> "3" :> Get '[JSON] Int
  :<|> "4" :> Get '[JSON] Int
  :<|> "5" :> Get '[JSON] Int
  :<|> "6" :> Get '[JSON] Int

type ApiChunky2
  =    ("1" :> Get '[JSON] Int
   :<|> "2" :> Get '[JSON] Int)
  :<|> ("3" :> Get '[JSON] Int
   :<|> "4" :> Get '[JSON] Int)
  :<|> ("5" :> Get '[JSON] Int
   :<|> "6" :> Get '[JSON] Int)

type ApiChunky3
  =    ("1" :> Get '[JSON] Int
   :<|> "2" :> Get '[JSON] Int
   :<|> "3" :> Get '[JSON] Int)
  :<|> ("4" :> Get '[JSON] Int
   :<|> "5" :> Get '[JSON] Int
   :<|> "6" :> Get '[JSON] Int)
```

I _think_ that the "chunky" APIs have better compile-time performance, but I need to prove that. Once I've determined if that's true or not, I'll change this PR from a draft. 

---

- [ ] I manually tested the code locally to make sure that it works.
- [ ] If there is documentation, I made sure it's accurate and up to date.
- [ ] If possible, I wrote automated tests for the new behavior.
