### PR TITLE
Add flag for excluding modules by suffix

### DIFF
--- a/source/library/ServantSerf/Module.hs
+++ b/source/library/ServantSerf/Module.hs
@@ -24,6 +24,7 @@ generate context files =
       fmap ModuleName.toString
         . List.sort
         . Maybe.mapMaybe ModuleName.fromFilePath
+        . Filter (List.isSuffixOf $ Config.suffix config)
         $ filter (FilePath.isExtensionOf "hs") files
   in unlines
     [ "{-# LINE 1 " <> show source <> " #-}"

--- a/source/library/ServantSerf/Module.hs
+++ b/source/library/ServantSerf/Module.hs
@@ -24,7 +24,7 @@ generate context files =
       fmap ModuleName.toString
         . List.sort
         . Maybe.mapMaybe ModuleName.fromFilePath
-        . filter (List.isSuffixOf $ Config.suffix config)
+        . filter (not . List.isSuffixOf (Config.suffix config))
         $ filter (FilePath.isExtensionOf "hs") files
   in unlines
     [ "{-# LINE 1 " <> show source <> " #-}"

--- a/source/library/ServantSerf/Module.hs
+++ b/source/library/ServantSerf/Module.hs
@@ -24,7 +24,7 @@ generate context files =
       fmap ModuleName.toString
         . List.sort
         . Maybe.mapMaybe ModuleName.fromFilePath
-        . Filter (List.isSuffixOf $ Config.suffix config)
+        . filter (List.isSuffixOf $ Config.suffix config)
         $ filter (FilePath.isExtensionOf "hs") files
   in unlines
     [ "{-# LINE 1 " <> show source <> " #-}"

--- a/source/library/ServantSerf/Module.hs
+++ b/source/library/ServantSerf/Module.hs
@@ -21,7 +21,7 @@ generate context files =
           $ Context.source context
       Just x -> ModuleName.toString x
     moduleNames =
-      filter (not . List.isSuffixOf (Config.suffix config))
+      filter (not . List.isSuffixOf (Config.excludeSuffix config))
         . fmap ModuleName.toString
         . List.sort
         . Maybe.mapMaybe ModuleName.fromFilePath

--- a/source/library/ServantSerf/Module.hs
+++ b/source/library/ServantSerf/Module.hs
@@ -21,10 +21,10 @@ generate context files =
           $ Context.source context
       Just x -> ModuleName.toString x
     moduleNames =
-      fmap ModuleName.toString
+      filter (not . List.isSuffixOf (Config.suffix config))
+        . fmap ModuleName.toString
         . List.sort
         . Maybe.mapMaybe ModuleName.fromFilePath
-        . filter (not . List.isSuffixOf (Config.suffix config))
         $ filter (FilePath.isExtensionOf "hs") files
   in unlines
     [ "{-# LINE 1 " <> show source <> " #-}"

--- a/source/library/ServantSerf/Type/Config.hs
+++ b/source/library/ServantSerf/Type/Config.hs
@@ -14,6 +14,7 @@ data Config = Config
   , help :: Bool
   , moduleName :: Maybe ModuleName.ModuleName
   , serverName :: String
+  , suffix :: String
   , version :: Bool
   }
   deriving (Eq, Show)
@@ -32,6 +33,7 @@ applyFlag config flag = case flag of
     Nothing -> Exception.throwM $ InvalidModuleName.InvalidModuleName x
     Just y -> pure config { moduleName = Just y }
   Flag.ServerName x -> pure config { serverName = x }
+  Flag.Suffix x -> pure config { suffix = x }
   Flag.Version -> pure config { version = True }
 
 initial :: Config
@@ -41,5 +43,6 @@ initial = Config
   , help = False
   , moduleName = Nothing
   , serverName = "server"
+  , suffix = ""
   , version = False
   }

--- a/source/library/ServantSerf/Type/Config.hs
+++ b/source/library/ServantSerf/Type/Config.hs
@@ -11,10 +11,10 @@ import qualified ServantSerf.Type.ModuleName as ModuleName
 data Config = Config
   { apiName :: String
   , depth :: Depth.Depth
+  , excludeSuffix :: String
   , help :: Bool
   , moduleName :: Maybe ModuleName.ModuleName
   , serverName :: String
-  , suffix :: String
   , version :: Bool
   }
   deriving (Eq, Show)
@@ -28,21 +28,21 @@ applyFlag config flag = case flag of
   Flag.Depth x -> case Depth.fromString x of
     Nothing -> Exception.throwM $ InvalidDepth.InvalidDepth x
     Just y -> pure config { depth = y }
+  Flag.ExcludeSuffix x -> pure config { excludeSuffix = x }
   Flag.Help -> pure config { help = True }
   Flag.ModuleName x -> case ModuleName.fromString x of
     Nothing -> Exception.throwM $ InvalidModuleName.InvalidModuleName x
     Just y -> pure config { moduleName = Just y }
   Flag.ServerName x -> pure config { serverName = x }
-  Flag.Suffix x -> pure config { suffix = x }
   Flag.Version -> pure config { version = True }
 
 initial :: Config
 initial = Config
   { apiName = "API"
   , depth = Depth.Deep
+  , excludeSuffix = ""
   , help = False
   , moduleName = Nothing
   , serverName = "server"
-  , suffix = ""
   , version = False
   }

--- a/source/library/ServantSerf/Type/Flag.hs
+++ b/source/library/ServantSerf/Type/Flag.hs
@@ -5,10 +5,10 @@ import qualified System.Console.GetOpt as Console
 data Flag
     = ApiName String
     | Depth String
+    | ExcludeSuffix String
     | Help
     | ModuleName String
     | ServerName String
-    | Suffix String
     | Version
     deriving (Eq, Show)
 
@@ -36,6 +36,11 @@ options =
     "Controls whether to search through only one directory (`shallow`) or recursively (`deep`). Defaults to `deep`."
   , Console.Option
     []
+    ["exclude-suffix"]
+    (Console.ReqArg ExcludeSuffix "SUFFIX")
+    "Sets the module suffix to exclude. Defaults to the empty string."
+  , Console.Option
+    []
     ["module-name"]
     (Console.ReqArg ModuleName "MODULE_NAME")
     "Sets the name of the generated module. By default this is generated from the source file name."
@@ -44,9 +49,4 @@ options =
     ["server-name"]
     (Console.ReqArg ServerName "SERVER_NAME")
     "Sets the name to use for the server value. Defaults to `server`."
-  , Console.Option
-    []
-    ["suffix"]
-    (Console.ReqArg Suffix "SUFFIX")
-    "Sets the module suffix to match on. Defaults to the empty string."
   ]

--- a/source/library/ServantSerf/Type/Flag.hs
+++ b/source/library/ServantSerf/Type/Flag.hs
@@ -8,6 +8,7 @@ data Flag
     | Help
     | ModuleName String
     | ServerName String
+    | Suffix String
     | Version
     deriving (Eq, Show)
 
@@ -43,4 +44,9 @@ options =
     ["server-name"]
     (Console.ReqArg ServerName "SERVER_NAME")
     "Sets the name to use for the server value. Defaults to `server`."
+  , Console.Option
+    []
+    ["suffix"]
+    (Console.ReqArg Suffix "SUFFIX")
+    "Sets the module suffix to match on. Defaults to the empty string."
   ]


### PR DESCRIPTION
Sometimes you may have actual handlers mixed together with other modules (like tests) in a single directory. This PR adds an `--exclude-suffix` flag for excluding modules based on the suffix of their name. For example you may use `--exclude-suffix=Spec` to exclude spec modules. 

I think it would be better to have a generic mechanism for including or excluding modules (or files) based on a pattern, but that's a bigger ask. However such a mechanism could in theory replace the `--depth` option by allowing you to say `--include '**/*.hs` for deep or `--include '*.hs'` for shallow. Similarly this functionality could be covered by `--exclude '**/*Spec.hs'` for files, or `--exclude '**.*Spec'` for modules. 

---

- [ ] I manually tested the code locally to make sure that it works.
- [ ] If there is documentation, I made sure it's accurate and up to date.
- [ ] If possible, I wrote automated tests for the new behavior.
