### PR TITLE
Fix suffix checking

### DIFF
--- a/source/library/ServantSerf/Module.hs
+++ b/source/library/ServantSerf/Module.hs
@@ -20,8 +20,9 @@ generate context files =
           . ModuleName.fromFilePath
           $ Context.source context
       Just x -> ModuleName.toString x
+    suffix = Config.excludeSuffix config
     moduleNames =
-      filter (not . List.isSuffixOf (Config.excludeSuffix config))
+      (if null suffix then id else filter $ not . List.isSuffixOf suffix)
         . fmap ModuleName.toString
         . List.sort
         . Maybe.mapMaybe ModuleName.fromFilePath


### PR DESCRIPTION
If you don't specify `--exclude-suffix`, all modules would end up getting excluded. This PR fixes that behavior. 

---

- [ ] I manually tested the code locally to make sure that it works.
- [ ] If there is documentation, I made sure it's accurate and up to date.
- [ ] If possible, I wrote automated tests for the new behavior.
